### PR TITLE
Reincluding flash alerts

### DIFF
--- a/app/views/layouts/_flash_alerts.html.erb
+++ b/app/views/layouts/_flash_alerts.html.erb
@@ -1,7 +1,10 @@
 <% flash.each do |key, value| %>
-  <div class="alert alert-<%= key %>">
-    <div class="container">
-      <%= value %>
-    </div>
+	<% if key == "alert" %>
+		<div class="alert alert-danger">
+	<% else %>
+  	<div class="alert alert-#{key}">
+  <% end %>
+     <%= value %>
+     <button class="close" data-dismiss="alert">×</button>
   </div>
 <% end %>

--- a/app/views/layouts/_flash_alerts.html.erb
+++ b/app/views/layouts/_flash_alerts.html.erb
@@ -1,7 +1,7 @@
 <% flash.each do |key, value| %>
   <div class="alert alert-<%= key %>">
     <div class="container">
-       <%= value %>
+      <%= value %>
     </div>
   </div>
 <% end %>

--- a/app/views/layouts/_flash_alerts.html.erb
+++ b/app/views/layouts/_flash_alerts.html.erb
@@ -1,8 +1,8 @@
 <% flash.each do |key, value| %>
-	<% if key == "alert" %>
-		<div class="alert alert-danger">
-	<% else %>
-  	<div class="alert alert-#{key}">
+  <% if key == "alert" %>
+    <div class="alert alert-danger">
+  <% else %>
+    <div class="alert alert-#{key}">
   <% end %>
      <%= value %>
      <button class="close" data-dismiss="alert">×</button>

--- a/app/views/layouts/_flash_alerts.html.erb
+++ b/app/views/layouts/_flash_alerts.html.erb
@@ -1,0 +1,7 @@
+<% flash.each do |key, value| %>
+  <div class="alert alert-<%= key %>">
+    <div class="container">
+       <%= value %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
   <body>
     <div class="wrap">
       <%= render 'layouts/header' %>
+      <%= render 'layouts/flash_alerts' %>
       <div class="two-column">
         <%= render 'layouts/sidebar' %>
         <div class="two-column__body">

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -12,6 +12,7 @@
         <div class="middle">
           <div class="inner">
             <img id="logo" src="<%= image_path('logo_white.png') %>" alt="logo" width="150">
+            <%= render 'layouts/flash_alerts' %>
             <%= yield %>
           </div>
         </div>


### PR DESCRIPTION
Not sure why the flash_alerts.html.erb partial is rendering lines 2-4 more indented than others. Might need fixed at some point, but still functional. Closes #62 