### PR TITLE
Remove unused tables

### DIFF
--- a/db/migrate/20160716201127_remove_views.rb
+++ b/db/migrate/20160716201127_remove_views.rb
@@ -1,0 +1,5 @@
+class RemoveViews < ActiveRecord::Migration
+  def change
+    drop_table :views
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160706175609) do
+ActiveRecord::Schema.define(version: 20160716201127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -151,24 +151,6 @@ ActiveRecord::Schema.define(version: 20160706175609) do
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
-
-  create_table "views", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-  end
-
-  add_index "views", ["email"], name: "index_views_on_email", unique: true, using: :btree
-  add_index "views", ["reset_password_token"], name: "index_views_on_reset_password_token", unique: true, using: :btree
 
   add_foreign_key "document_user_case_infos", "user_case_infos"
   add_foreign_key "document_user_case_infos", "user_documents"


### PR DESCRIPTION
The views table was created by accident during an earlier migration.
This removes the table as it's unneeded

Closes #99 (other tables were removed in another commit)
